### PR TITLE
Doc to increase the amount of RAM used by default on Docker Toolbox VM

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ To Install Docker in Windows XP/VISTA/7/8/8.1/10 others than Pro/Enterprise use 
 When using Docker Toolbox, mounting folders in a docker container can be a bit complicated and has certain limitations.
 The main limitation is that by default we will only be able to mount folders that are inside the C:/Users folder.
 
-To be able to process NIFTI volumes that we have in our Windows PC we will go to the folder C:/Users and create a folder called docker_shared_folder This folder that we have just created will be our work folder in which we will place all the volumes that we want to process using the SCT.
+To be able to process NIFTI volumes that we have in our Windows PC we will go to the folder **C:/Users** and create a folder called **docker_shared_folder** This folder that we have just created will be our work folder in which we will place all the volumes that we want to process using the SCT.
 
 
 Online Installation
@@ -58,6 +58,21 @@ Online Installation
    .. code:: sh
 
       docker pull neuropoly/sct:sct-3.2.1-official
+
+#. If you are **NOT** using Docker Toolbox skip this step. To avoid memory issues when running the SCT is important to increment the default amount of RAM (1GB) of the Docker VM. Tho do this:
+
+   Open Docker Quickstart Terminal wait until get a prompt and run:
+
+   .. code:: sh
+
+      docker-machine stop default
+
+      /c/Program\ Files/Oracle/VirtualBox/VBoxManage.exe modifyvm default --memory 2048
+
+      docker-machine start default
+
+    Note: With these commands we have increased the RAM memory of the VM Docker to 2GB. It is important that your PC have at least 3 GB of RAM in order to let at least 1 GB for your Windows host system.
+
 
 #. Go to C:/Users and create the folder named **docker_shared_folder**
 
@@ -81,6 +96,20 @@ Offline Installation
       docker load --input sct-3.2.1-official-ubuntu_18.04.tar
 
     After the --input parameter you can include the complete path where the docker image is located. In the example it is assumed that the image is in the current directory
+
+#. If you are **NOT** using Docker Toolbox skip this step. To avoid memory issues when running the SCT is important to increment the default amount of RAM (1GB) of the Docker VM. Tho do this:
+
+   Open Docker Quickstart Terminal wait until get a prompt and run:
+
+   .. code:: sh
+
+      docker-machine stop default
+
+      /c/Program\ Files/Oracle/VirtualBox/VBoxManage.exe modifyvm default --memory 2048
+
+      docker-machine start default
+
+    Note: With these commands we have increased the RAM memory of the VM Docker to 2GB. It is important that your PC have at least 3 GB of RAM in order to let at least 1 GB for your Windows host system.
 
 #. Go to **C:/Users** and create the folder named **docker_shared_folder**
 

--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ Online Installation
 
       docker pull neuropoly/sct:sct-3.2.1-official
 
-#. If you are **NOT** using Docker Toolbox skip this step. To avoid memory issues when running the SCT is important to increment the default amount of RAM (1GB) of the Docker VM. Tho do this:
+#. If you are **NOT** using Docker Toolbox skip this step. To avoid memory issues when running the SCT is important to increment the default amount of RAM (1GB) of the Docker VM. To do this:
 
    Open Docker Quickstart Terminal wait until get a prompt and run:
 
@@ -71,7 +71,7 @@ Online Installation
 
       docker-machine start default
 
-    Note: With these commands we have increased the RAM memory of the VM Docker to 2GB. It is important that your PC have at least 3 GB of RAM in order to let at least 1 GB for your Windows host system.
+    Note: With these commands we have increased the RAM memory of the VM Docker to 2GB. It is important that your PC have at least 3 GB of RAM in order to leave at least 1 GB for your Windows host system.
 
 
 #. Go to C:/Users and create the folder named **docker_shared_folder**
@@ -97,7 +97,7 @@ Offline Installation
 
     After the --input parameter you can include the complete path where the docker image is located. In the example it is assumed that the image is in the current directory
 
-#. If you are **NOT** using Docker Toolbox skip this step. To avoid memory issues when running the SCT is important to increment the default amount of RAM (1GB) of the Docker VM. Tho do this:
+#. If you are **NOT** using Docker Toolbox skip this step. To avoid memory issues when running the SCT is important to increment the default amount of RAM (1GB) of the Docker VM. To do this:
 
    Open Docker Quickstart Terminal wait until get a prompt and run:
 
@@ -109,7 +109,7 @@ Offline Installation
 
       docker-machine start default
 
-    Note: With these commands we have increased the RAM memory of the VM Docker to 2GB. It is important that your PC have at least 3 GB of RAM in order to let at least 1 GB for your Windows host system.
+    Note: With these commands we have increased the RAM memory of the VM Docker to 2GB. It is important that your PC have at least 3 GB of RAM in order to leave at least 1 GB for your Windows host system.
 
 #. Go to **C:/Users** and create the folder named **docker_shared_folder**
 


### PR DESCRIPTION
Doc to increase the amount of RAM used by default on Docker Toolbox VM using the command line

Fix issue #7