### PR TITLE
Documentation improvements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,12 +63,12 @@ Installation
 ************
 
 
-#. Install git (in case you don't already have it), this is to provide
+#. Install `git <https://git-scm.com/download/win>`_ (in case you don't already have it), this is to provide
    an SSH binary.
 
 #. Install `Xming <https://sourceforge.net/projects/xming/files/Xming/6.9.0.31/>`_.
 
-#. Install Docker (or Docker Toolbox depending of your Windows version).
+#. Install `Docker <https://store.docker.com/editions/community/docker-ce-desktop-windows/>`_ (or `Docker Toolbox <https://docs.docker.com/toolbox/overview/>`_ depending of your Windows version).
 
 #. Fetch the SCT image
 
@@ -165,8 +165,7 @@ Usage
 #. Connect to it using Xming/SSH if X forwarding is needed
    (eg. running FSLeyes from there):
 
-   Run (double click) ``windows/sct-win.xlaunch`` found in this
-   repository. If you are using docker toolbox then then
+   Clone the current repository & run (double click) ``windows/sct-win.xlaunch``. If you are using docker toolbox then then
    run ``windows/sct-win_docker_toolbox.xlaunch``
 
    If this is the first time you have done this procedure, the system


### PR DESCRIPTION
Based on : 
Feedback for sct_docker on Windows:
Docker for Windows - Installation
   - 1. add link to git
   - 3. add link to Docker (the link is higher on the page, but  I find it more convenient to add it here)

Docker for Windows - Usage
   - 3. It should be specified that the user has to download/clone the repository in order to setup Xming

General comment: Docker is pretty slow to install & start (~5-10 min) . Tested on win10 pro, CPU i3-7100, 8Gb RAM.