### PR TITLE
Lr/fingerprint error

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -298,7 +298,18 @@ Usage
    container) as trust pc, type ``yes``. Then type the
    password to enter the docker container (by default ``sct``).
 
-   The graphic terminal emulator LXterminal should appear, which
+   If there is no new open windows :
+	- Double click on the 'windows/Erase_fingerprint_docker' program
+	- Try again 
+	- if it is still not working : 
+		- Open the file manager and go to C:/Users/Your_username
+		- In the searchbar type '.ssh'
+		- Open the found '.ssh' folder.
+		- Open the 'known_hosts' file with a text editor
+		- Remove line starting with `192.168.99.100` or `localhost`
+		- try again 
+
+   The graphic terminal emulator LXterminal should appear (if not check the task bar at the bottom of the screen), which
    allows copying and pasting commands, which makes it easier for
    users to use it.
    To check that X forwarding is working well write ``fsleyes &`` in

--- a/windows/Erase_fingerprint_docker.sh
+++ b/windows/Erase_fingerprint_docker.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+#
+grep -v "192.168.99.100" ~/.ssh/known_hosts | grep -v "localhost" > ~/.ssh/known_hosts.txt
+cat ~/.ssh/known_hosts.txt > ~/.ssh/known_hosts
+rm ~/.ssh/known_hosts.txt

--- a/windows/Erase_fingerprint_docker.sh
+++ b/windows/Erase_fingerprint_docker.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 #
-grep -v "192.168.99.100" ~/.ssh/known_hosts | grep -v "localhost" > ~/.ssh/known_hosts.txt
+grep -v "192.168.99.100" ~/.ssh/known_hosts | grep -v "localhost" | grep -v "127.0.0.1" > ~/.ssh/known_hosts.txt
 cat ~/.ssh/known_hosts.txt > ~/.ssh/known_hosts
 rm ~/.ssh/known_hosts.txt


### PR DESCRIPTION
This PR aims to help the user fix the Xming ssh link with the Docker machine. The error can happen if he works on multiple versions. A shell script has been added to remove previously existing the previous fingerprints of the docker-machine. This is necessary to give permission for the connexion to the new container, which runs the new version.
The script main advantages are that it works on multiple OS and that you just need to double click on it to run it. It is available in the 'windows' folder. 
This PR also add a paragraph about a separate fix in case the scripts fail.
Fixes #47 