### PR TITLE
Add documentation for window subsystem for linux (WIP)

### DIFF
--- a/Install_WSL.rst
+++ b/Install_WSL.rst
@@ -58,7 +58,7 @@ To select a [specific release](https://github.com/neuropoly/spinalcordtoolbox/re
 
   git checkout X.Y.Z
 
-To install SCT run:
+Install SCT:
 
 .. code:: sh
  

--- a/Install_WSL.rst
+++ b/Install_WSL.rst
@@ -87,6 +87,7 @@ to complete the installation of these software run:
 
 .. code:: sh
 
+    cd ~
     source .profile
 
 You can now use SCT. To use FSLeyes, run Xming from your computer before entering the fsleyes command.

--- a/Install_WSL.rst
+++ b/Install_WSL.rst
@@ -1,0 +1,86 @@
+.. -*- coding: utf-8; indent-tabs-mode:nil; -*-
+
+##########################
+Spinal Cord Toolbox Docker
+##########################
+
+This documentation shows how to install the latest version of SCT. If you want install a different version of SCT please specify the version number you want.
+
+.. contents::
+..
+    1  Windows subsystem for linux 
+    2  environment preparation
+    3  SCT installation 
+    4  FSL installation 
+    5  Usage 
+
+Installation
+************
+
+
+#. Install `Xming <https://sourceforge.net/projects/xming/files/Xming/6.9.0.31/>`_.
+
+#. Install `Windows subsystem for linux <https://docs.microsoft.com/en-us/windows/wsl/install-win10>` and initialize it.
+	- Please install the Ubuntu 18.04 LTS distro. 
+
+Environment preparation
+***********************
+
+Run the following command to install various packages that will be needed to install FSL and SCT. This will require your password
+~~~
+sudo apt-get -y update
+sudo apt-get -y install gcc
+sudo apt-get -y install unzip
+sudo apt-get install -y python-pip python
+
+sudo sudo apt-get install -y psmisc net-tools
+sudo sudo apt-get install -y git
+sudo sudo apt-get install -y gfortran
+
+
+sudo sudo apt-get install -y libjpeg-dev
+
+echo 'export DISPLAY=127.0.0.1:0.0' >> .profile
+~~~
+
+Install SCT
+*********** 
+
+run the following command to download SCT:
+`wget https://github.com/neuropoly/spinalcordtoolbox/archive/4.2.1.zip`
+
+Once the download is complete run this command to extract SCT from the zip archive:
+`unzip 4.2.1.zip`
+
+Then go inside the folder by running: 
+`cd spinalcordtoolbox-4.2.1`
+
+To install SCT run: 
+`yes | ./install_sct`
+
+To complete the installation you need to run:
+~~~
+cd
+echo 'export SCT_DIR=/home/sct/sct_dev' >> .profile
+~~~
+
+Install FSL
+***********
+
+FSL contains fsleyes which is the default viewer for mifti image in SCT. 
+Run this to download the installer and execute it: 
+~~~
+wget https://fsl.fmrib.ox.ac.uk/fsldownloads/fslinstaller.py
+
+python fslinstaller.py 
+~~~
+
+to complete the installation of these software run: 
+`source .profile`
+
+You can now use SCT. To use FSLeyes, run Xming from your computer before entering the `fsleyes` command.
+
+Your local C drive is located under `/mnt/c`. You can acces it by running `cd /mnt/c`
+
+
+ 

--- a/Install_WSL.rst
+++ b/Install_WSL.rst
@@ -18,7 +18,7 @@ Installation
 ************
 
 
-#. Install `Xming <https://sourceforge.net/projects/xming/files/Xming/6.9.0.31/>`_.
+#. Install `Xming <https://sourceforge.net/projects/xming/>`_.
 
 #. Install  `Windows subsystem for linux and initialize it <https://docs.microsoft.com/en-us/windows/wsl/install-win10>`_. 
 

--- a/Install_WSL.rst
+++ b/Install_WSL.rst
@@ -4,7 +4,7 @@
 Spinal Cord Toolbox for Windows : Windows subsystem for linux
 ############################################################
 
-This documentation shows how to install the latest version of SCT. If you want install a different version of SCT please specify the version number you want.
+This documentation shows how to install the latest version of SCT. If you want to install a different version of SCT please specify the version number.
 
 .. contents::
 ..

--- a/Install_WSL.rst
+++ b/Install_WSL.rst
@@ -20,7 +20,7 @@ Installation
 
 #. Install `Xming <https://sourceforge.net/projects/xming/files/Xming/6.9.0.31/>`_.
 
-#. Install `Windows subsystem for linux <https://docs.microsoft.com/en-us/windows/wsl/install-win10>`_ and initialize it.
+#. Install `Windows subsystem for linux and initialize it <https://docs.microsoft.com/en-us/windows/wsl/install-win10>`_. 
 	- Please install the Ubuntu 18.04 LTS distro. 
 
 Environment preparation

--- a/Install_WSL.rst
+++ b/Install_WSL.rst
@@ -20,59 +20,80 @@ Installation
 
 #. Install `Xming <https://sourceforge.net/projects/xming/files/Xming/6.9.0.31/>`_.
 
-#. Install _`Windows subsystem for linux <https://docs.microsoft.com/en-us/windows/wsl/install-win10>`_ and initialize it.
+#. Install `Windows subsystem for linux <https://docs.microsoft.com/en-us/windows/wsl/install-win10>`_ and initialize it.
 	- Please install the Ubuntu 18.04 LTS distro. 
 
 Environment preparation
 ***********************
 
 Run the following command to install various packages that will be needed to install FSL and SCT. This will require your password
-..code-block:: shell
-sudo apt-get -y update
-sudo apt-get -y install gcc
-sudo apt-get -y install unzip
-sudo apt-get install -y python-pip python
-sudo sudo apt-get install -y psmisc net-tools
-sudo sudo apt-get install -y git
-sudo sudo apt-get install -y gfortran
-sudo sudo apt-get install -y libjpeg-dev
-echo 'export DISPLAY=127.0.0.1:0.0' >> .profile
+
+.. code-block:: sh
+
+    sudo apt-get -y update
+    sudo apt-get -y install gcc
+    sudo apt-get -y install unzip
+    sudo apt-get install -y python-pip python
+    sudo apt-get install -y psmisc net-tools
+    sudo apt-get install -y git
+    sudo apt-get install -y gfortran
+    sudo apt-get install -y libjpeg-dev
+    echo 'export DISPLAY=127.0.0.1:0.0' >> .profile
 
 
 Install SCT
 *********** 
 
 run the following command to download SCT:
-`wget https://github.com/neuropoly/spinalcordtoolbox/archive/4.2.1.zip`
+
+.. code:: sh
+
+    wget https://github.com/neuropoly/spinalcordtoolbox/archive/4.2.1.zip
 
 Once the download is complete run this command to extract SCT from the zip archive:
-`unzip 4.2.1.zip`
 
-Then go inside the folder by running: 
-`cd spinalcordtoolbox-4.2.1`
+.. code:: sh
 
-To install SCT run: 
-`yes | ./install_sct`
+    unzip 4.2.1.zip
+
+Then go inside the folder by running:
+
+.. code:: sh 
+
+    cd spinalcordtoolbox-4.2.1
+
+To install SCT run:
+
+.. code:: sh
+ 
+    yes | ./install_sct
 
 To complete the installation you need to run:
-..code-block:: shell
-cd
-echo 'export SCT_DIR=/home/sct/sct_dev' >> .profile
+
+.. code-block:: sh
+
+    cd
+    echo 'export SCT_DIR=/home/sct/sct_dev' >> .profile
 
 
 Install FSL
 ***********
 
 FSL contains fsleyes which is the default viewer for mifti image in SCT. 
-Run this to download the installer and execute it: 
-..code-block:: shell
-wget https://fsl.fmrib.ox.ac.uk/fsldownloads/fslinstaller.py
-python fslinstaller.py 
+Run this to download the installer and execute it:
+ 
+.. code-block:: sh
+
+    wget https://fsl.fmrib.ox.ac.uk/fsldownloads/fslinstaller.py
+    python fslinstaller.py 
 
 to complete the installation of these software run: 
-`source .profile`
 
-You can now use SCT. To use FSLeyes, run Xming from your computer before entering the `fsleyes` command.
+.. code:: sh
+
+    source .profile
+
+You can now use SCT. To use FSLeyes, run Xming from your computer before entering the fsleyes command.
 
 Your local C drive is located under '/mnt/c'. You can acces it by running `cd /mnt/c`
 

--- a/Install_WSL.rst
+++ b/Install_WSL.rst
@@ -1,7 +1,7 @@
 .. -*- coding: utf-8; indent-tabs-mode:nil; -*-
 
 ############################################################
-Spinal Cord Toolbox for Windows : Windows subsyetm for linux
+Spinal Cord Toolbox for Windows : Windows subsystem for linux
 ############################################################
 
 This documentation shows how to install the latest version of SCT. If you want install a different version of SCT please specify the version number you want.

--- a/Install_WSL.rst
+++ b/Install_WSL.rst
@@ -75,7 +75,7 @@ To complete the installation you need to run:
 Install FSL
 ***********
 
-FSL contains fsleyes which is the default viewer for mifti image in SCT. 
+FSL contains fsleyes which is the default viewer for NIfTI image in SCT. 
 Download and execute the installer:
  
 .. code-block:: sh

--- a/Install_WSL.rst
+++ b/Install_WSL.rst
@@ -45,23 +45,18 @@ Run the following command to install various packages that will be needed to ins
 Install SCT
 *********** 
 
-run the following command to download SCT:
+Download SCT:
 
-.. code:: sh
+.. code-block:: sh
 
-    wget https://github.com/neuropoly/spinalcordtoolbox/archive/4.2.1.zip
+  git clone https://github.com/neuropoly/spinalcordtoolbox.git sct
+  cd sct
 
-Once the download is complete run this command to extract SCT from the zip archive:
+To select a [specific release](https://github.com/neuropoly/spinalcordtoolbox/releases), replace X.Y.Z below with the proper release number. If you prefer to use the development version, you can skip this step.
 
-.. code:: sh
+.. code-block:: sh
 
-    unzip 4.2.1.zip
-
-Then go inside the folder by running:
-
-.. code:: sh 
-
-    cd spinalcordtoolbox-4.2.1
+  git checkout X.Y.Z
 
 To install SCT run:
 

--- a/Install_WSL.rst
+++ b/Install_WSL.rst
@@ -64,12 +64,6 @@ Install SCT:
  
     yes | ./install_sct
 
-To complete the installation you need to run:
-
-.. code-block:: sh
-
-    cd
-    echo 'export SCT_DIR=/home/sct/sct_dev' >> .profile
 
 
 Install FSL
@@ -89,6 +83,7 @@ to complete the installation of these software run:
 
     cd ~
     source .profile
+    source .bashrc
 
 You can now use SCT. To use FSLeyes, run Xming from your computer before entering the fsleyes command.
 

--- a/Install_WSL.rst
+++ b/Install_WSL.rst
@@ -1,8 +1,8 @@
 .. -*- coding: utf-8; indent-tabs-mode:nil; -*-
 
-##########################
-Spinal Cord Toolbox Docker
-##########################
+############################################################
+Spinal Cord Toolbox for Windows : Windows subsyetm for linux
+############################################################
 
 This documentation shows how to install the latest version of SCT. If you want install a different version of SCT please specify the version number you want.
 
@@ -95,7 +95,11 @@ to complete the installation of these software run:
 
 You can now use SCT. To use FSLeyes, run Xming from your computer before entering the fsleyes command.
 
-Your local C drive is located under '/mnt/c'. You can acces it by running `cd /mnt/c`
+Your local C drive is located under '/mnt/c'. You can access it by running 
+
+.. code:: sh
+
+    cd /mnt/c
 
 
  

--- a/Install_WSL.rst
+++ b/Install_WSL.rst
@@ -20,7 +20,8 @@ Installation
 
 #. Install `Xming <https://sourceforge.net/projects/xming/files/Xming/6.9.0.31/>`_.
 
-#. Install `Windows subsystem for linux and initialize it <https://docs.microsoft.com/en-us/windows/wsl/install-win10>`_. 
+#. Install  `Windows subsystem for linux and initialize it <https://docs.microsoft.com/en-us/windows/wsl/install-win10>`_. 
+
 	- Please install the Ubuntu 18.04 LTS distro. 
 
 Environment preparation

--- a/Install_WSL.rst
+++ b/Install_WSL.rst
@@ -20,28 +20,24 @@ Installation
 
 #. Install `Xming <https://sourceforge.net/projects/xming/files/Xming/6.9.0.31/>`_.
 
-#. Install `Windows subsystem for linux <https://docs.microsoft.com/en-us/windows/wsl/install-win10>` and initialize it.
+#. Install _`Windows subsystem for linux <https://docs.microsoft.com/en-us/windows/wsl/install-win10>`_ and initialize it.
 	- Please install the Ubuntu 18.04 LTS distro. 
 
 Environment preparation
 ***********************
 
 Run the following command to install various packages that will be needed to install FSL and SCT. This will require your password
-~~~
+..code-block:: shell
 sudo apt-get -y update
 sudo apt-get -y install gcc
 sudo apt-get -y install unzip
 sudo apt-get install -y python-pip python
-
 sudo sudo apt-get install -y psmisc net-tools
 sudo sudo apt-get install -y git
 sudo sudo apt-get install -y gfortran
-
-
 sudo sudo apt-get install -y libjpeg-dev
-
 echo 'export DISPLAY=127.0.0.1:0.0' >> .profile
-~~~
+
 
 Install SCT
 *********** 
@@ -59,28 +55,26 @@ To install SCT run:
 `yes | ./install_sct`
 
 To complete the installation you need to run:
-~~~
+..code-block:: shell
 cd
 echo 'export SCT_DIR=/home/sct/sct_dev' >> .profile
-~~~
+
 
 Install FSL
 ***********
 
 FSL contains fsleyes which is the default viewer for mifti image in SCT. 
 Run this to download the installer and execute it: 
-~~~
+..code-block:: shell
 wget https://fsl.fmrib.ox.ac.uk/fsldownloads/fslinstaller.py
-
 python fslinstaller.py 
-~~~
 
 to complete the installation of these software run: 
 `source .profile`
 
 You can now use SCT. To use FSLeyes, run Xming from your computer before entering the `fsleyes` command.
 
-Your local C drive is located under `/mnt/c`. You can acces it by running `cd /mnt/c`
+Your local C drive is located under '/mnt/c'. You can acces it by running `cd /mnt/c`
 
 
  

--- a/Install_WSL.rst
+++ b/Install_WSL.rst
@@ -76,7 +76,7 @@ Install FSL
 ***********
 
 FSL contains fsleyes which is the default viewer for mifti image in SCT. 
-Run this to download the installer and execute it:
+Download and execute the installer:
  
 .. code-block:: sh
 


### PR DESCRIPTION
For windows 10 user , it might be better to use windows subsystem for Linux (WSL) instead of docker especially since Docker is dropping the support on Docker toolbox. 
This PR add documentation for the installation of FSLeyes and SCT in this context in a separate .rst file. It contains the following instruction : 
- Link for the installation of WSL 
-  for Xming installation (still needed for FSLeyes)
- Command to run to set up the environement to install FSL and SCT dependencies (e.g., gcc, gtk..) 
- Command to install sct from 4.2.1 archive
- Command to install FSL which will install FSLeyes
- A useful note about the location of certain files. 

TO DO : 

- Description of windows subsystem 
- Add link in the readme for Windows user to redirect them here 
